### PR TITLE
 In SX_LUTF8STR and SX_UTF8STR, decode as utf-8 before type guessing

### DIFF
--- a/storable/core.py
+++ b/storable/core.py
@@ -116,7 +116,8 @@ def SX_LSCALAR(fh, cache):
 
 @maybelogged
 def SX_LUTF8STR(fh, cache):
-    return SX_LSCALAR(fh, cache).decode('utf-8')
+    raw_result = fh.read(_read_size(fh, cache)).decode('utf-8')
+    return _guess_type(raw_result)
 
 
 @maybelogged
@@ -177,7 +178,9 @@ def SX_SCALAR(fh, cache):
 
 @maybelogged
 def SX_UTF8STR(fh, cache):
-    return SX_SCALAR(fh, cache).decode('utf-8')
+    size = _read_unsigned_byte(fh)
+    raw_result = fh.read(size).decode('utf-8')
+    return _guess_type(raw_result)
 
 
 @maybelogged


### PR DESCRIPTION
We can't assume a binary string return type from `SX_LSCALAR` or `SX_SCALAR` in the cases that `__guess_type` was successful.

Without this patch, I was getting this error:

```
@maybelogged
def SX_UTF8STR(fh, cache):
>       return SX_SCALAR(fh, cache).decode('utf-8')
E       AttributeError: 'float' object has no attribute 'decode'
```